### PR TITLE
Refactor `refactor` so that things are refactored.

### DIFF
--- a/rollback-auto-update.php
+++ b/rollback-auto-update.php
@@ -134,7 +134,7 @@ class Rollback_Auto_Update {
 	 *
 	 * @param array $handler_args Array of data.
 	 *
-	 * @return array|void
+	 * @return void
 	 */
 	public function shutdown_handler( $handler_args ) {
 		$e = error_get_last();
@@ -144,14 +144,12 @@ class Rollback_Auto_Update {
 		}
 
 		if ( 'Shutdown Caught' !== $this->handler_args['handler_error'] ) {
-			return $handler_args['result'];
+			return;
 		}
 
 		$handler_args['handler_error'] = $e['type'] & E_RECOVERABLE_ERROR ? 'Recoverable fatal error' : 'Fatal error';
 
 		$this->handler( $handler_args );
-
-		return $handler_args['result'];
 	}
 
 	/**

--- a/rollback-auto-update.php
+++ b/rollback-auto-update.php
@@ -194,19 +194,11 @@ class Rollback_Auto_Update {
 	 * new version contains a fatal error.
 	 *
 	 * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
-	 *
-	 * @param array $args {
-	 *    An array of error data.
-	 *
-	 *    @type string   $error      The error message.
-	 *    @type WP_Error $result     Generic WP_Error reporting unexpected output.
-	 *    @type array    $hook_extra Extra arguments that were passed to hooked filters.
-	 * }
 	 */
-	private function send_fatal_error_email( $args ) {
+	private function send_fatal_error_email() {
 		global $wp_filesystem;
 
-		$plugin_path = $wp_filesystem->wp_plugins_dir() . $args['hook_extra']['plugin'];
+		$plugin_path = $wp_filesystem->wp_plugins_dir() . $this->handler_args['hook_extra']['plugin'];
 		$name        = \get_plugin_data( $plugin_path )['Name'];
 		$body        = sprintf(
 			__( 'Howdy!' ) . "\n\n" .

--- a/rollback-auto-update.php
+++ b/rollback-auto-update.php
@@ -154,19 +154,11 @@ class Rollback_Auto_Update {
 	 * Rolls back during cron.
 	 *
 	 * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
-	 *
-	 * @param array $args {
-	 *    An array of error data.
-	 *
-	 *    @type string   $error      The error message.
-	 *    @type WP_Error $result     Generic WP_Error reporting unexpected output.
-	 *    @type array    $hook_extra Extra arguments that were passed to hooked filters.
-	 * }
 	 */
-	private function cron_rollback( $args ) {
+	private function cron_rollback() {
 		global $wp_filesystem;
 
-		$plugin      = $args['hook_extra']['plugin'];
+		$plugin      = $this->handler_args['hook_extra']['plugin'];
 		$temp_backup = [
 			'temp_backup' => [
 				'dir'  => 'plugins',

--- a/rollback-auto-update.php
+++ b/rollback-auto-update.php
@@ -218,20 +218,12 @@ class Rollback_Auto_Update {
 
 	/**
 	 * Outputs the handler error to the log file.
-	 *
-	 * @param array $args {
-	 *    An array of error data.
-	 *
-	 *    @type string   $error      The error message.
-	 *    @type WP_Error $result     Generic WP_Error reporting unexpected output.
-	 *    @type array    $hook_extra Extra arguments that were passed to hooked filters.
-	 * }
 	 */
-	private function log_error_msg( $args ) {
+	private function log_error_msg() {
 		$error_msg = sprintf(
 			'Rollback Auto-Update: %1$s in %2$s',
-			$args['handler_error'],
-			$args['hook_extra']['plugin']
+			$this->handler_args['handler_error'],
+			$this->handler_args['hook_extra']['plugin']
 		);
 		//phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		error_log( $error_msg );

--- a/rollback-auto-update.php
+++ b/rollback-auto-update.php
@@ -110,11 +110,9 @@ class Rollback_Auto_Update {
 	/**
 	 * Error handler function.
 	 *
-	 * @param \Error $error Error object.
-	 *
 	 * @return void
 	 */
-	public function error_handler( $error ) {
+	public function error_handler() {
 		$this->handler_args['handler_error'] = 'Error Caught';
 		$this->handler( $this->handler_args );
 	}

--- a/rollback-auto-update.php
+++ b/rollback-auto-update.php
@@ -84,7 +84,7 @@ class Rollback_Auto_Update {
 		];
 		$this->initialize_handlers();
 
-		// working parts of `plugin_sandbox_scrape()`.
+		// Working parts of `plugin_sandbox_scrape()`.
 		wp_register_plugin_realpath( WP_PLUGIN_DIR . '/' . $plugin );
 		if ( 'rollback-auto-update/rollback-auto-update.php' !== $plugin ) {
 			include WP_PLUGIN_DIR . '/' . $plugin;

--- a/rollback-auto-update.php
+++ b/rollback-auto-update.php
@@ -126,8 +126,6 @@ class Rollback_Auto_Update {
 	 * Liberally borrowed from John Blackbourn's Query Monitor.
 	 *
 	 * @param array $handler_args Array of data.
-	 *
-	 * @return void
 	 */
 	public function shutdown_handler( $handler_args ) {
 		$e = error_get_last();
@@ -155,8 +153,6 @@ class Rollback_Auto_Update {
 	 *    @type WP_Error $result     Generic WP_Error reporting unexpected output.
 	 *    @type array    $hook_extra Extra arguments that were passed to hooked filters.
 	 * }
-	 *
-	 * @return void
 	 */
 	private function handler( $args ) {
 		$this->cron_rollback( $args );
@@ -176,8 +172,6 @@ class Rollback_Auto_Update {
 	 *    @type WP_Error $result     Generic WP_Error reporting unexpected output.
 	 *    @type array    $hook_extra Extra arguments that were passed to hooked filters.
 	 * }
-	 *
-	 * @return void
 	 */
 	private function cron_rollback( $args ) {
 		global $wp_filesystem;
@@ -258,8 +252,6 @@ class Rollback_Auto_Update {
 	 *    @type WP_Error $result     Generic WP_Error reporting unexpected output.
 	 *    @type array    $hook_extra Extra arguments that were passed to hooked filters.
 	 * }
-	 *
-	 * @return void
 	 */
 	private function log_error_msg( $args ) {
 		$error_msg = sprintf(

--- a/rollback-auto-update.php
+++ b/rollback-auto-update.php
@@ -41,14 +41,14 @@ if ( ! defined( 'WPINC' ) ) {
 class Rollback_Auto_Update {
 
 	/**
-	 * Variable to store handler parameters.
+	 * Stores handler parameters.
 	 *
 	 * @var array
 	 */
 	private $handler_args = [];
 
 	/**
-	 * Variable to store error codes.
+	 * Stores error codes.
 	 *
 	 * @var int
 	 */
@@ -62,7 +62,7 @@ class Rollback_Auto_Update {
 	}
 
 	/**
-	 * Check validity of updated plugin.
+	 * Checks the validity of the updated plugin.
 	 *
 	 * @param array|WP_Error $result     Result from WP_Upgrader::install_package().
 	 * @param array          $hook_extra Extra arguments passed to hooked filters.
@@ -96,9 +96,7 @@ class Rollback_Auto_Update {
 	}
 
 	/**
-	 * Initialize handlers.
-	 *
-	 * @return void
+	 * Initializes handlers.
 	 */
 	private function initialize_handlers() {
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
@@ -108,9 +106,7 @@ class Rollback_Auto_Update {
 	}
 
 	/**
-	 * Error handler function.
-	 *
-	 * @return void
+	 * Handles Errors.
 	 */
 	public function error_handler() {
 		$this->handler_args['handler_error'] = 'Error Caught';
@@ -118,9 +114,7 @@ class Rollback_Auto_Update {
 	}
 
 	/**
-	 * Exception handler function.
-	 *
-	 * @return void
+	 * Handles Exceptions.
 	 */
 	public function exception_handler() {
 		$this->handler_args['handler_error'] = 'Exception Caught';
@@ -152,7 +146,7 @@ class Rollback_Auto_Update {
 	}
 
 	/**
-	 * Handle errors by running Rollback.
+	 * Handles errors by running Rollback.
 	 *
 	 * @param array $args {
 	 *    An array of error data.
@@ -171,7 +165,7 @@ class Rollback_Auto_Update {
 	}
 
 	/**
-	 * Rollback during cron.
+	 * Rolls back during cron.
 	 *
 	 * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
 	 *
@@ -255,7 +249,7 @@ class Rollback_Auto_Update {
 	}
 
 	/**
-	 * Undocumented function
+	 * Outputs the handler error to the log file.
 	 *
 	 * @param array $args {
 	 *    An array of error data.

--- a/rollback-auto-update.php
+++ b/rollback-auto-update.php
@@ -120,11 +120,9 @@ class Rollback_Auto_Update {
 	/**
 	 * Exception handler function.
 	 *
-	 * @param \Exception $exception Exception object.
-	 *
 	 * @return void
 	 */
-	public function exception_handler( $exception ) {
+	public function exception_handler() {
 		$this->handler_args['handler_error'] = 'Exception Caught';
 		$this->handler( $this->handler_args );
 	}

--- a/rollback-auto-update.php
+++ b/rollback-auto-update.php
@@ -48,7 +48,14 @@ class Rollback_Auto_Update {
 	private $handler_args = [];
 
 	/**
-	 * Let's get started.
+	 * Variable to store error codes.
+	 *
+	 * @var int
+	 */
+	public $error_types = E_ERROR | E_PARSE | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR;
+
+	/**
+	 * Constructor, let's get going.
 	 */
 	public function __construct() {
 		add_filter( 'upgrader_install_package_result', [ $this, 'auto_update_check' ], 15, 2 );
@@ -94,12 +101,8 @@ class Rollback_Auto_Update {
 	 * @return void
 	 */
 	private function initialize_handlers() {
-		if ( ! defined( 'QM_ERROR_FATALS' ) ) {
-			define( 'QM_ERROR_FATALS', E_ERROR | E_PARSE | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR );
-		}
-
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
-		set_error_handler( [ $this, 'error_handler' ], ( E_ALL ^ QM_ERROR_FATALS ) );
+		set_error_handler( [ $this, 'error_handler' ], ( E_ALL ^ $this->error_types ) );
 		set_exception_handler( [ $this, 'exception_handler' ] );
 		register_shutdown_function( [ $this, 'shutdown_handler' ], $this->handler_args );
 	}
@@ -139,7 +142,7 @@ class Rollback_Auto_Update {
 	public function shutdown_handler( $handler_args ) {
 		$e = error_get_last();
 
-		if ( empty( $e ) || ! ( $e['type'] & QM_ERROR_FATALS ) ) {
+		if ( empty( $e ) || ! ( $e['type'] & $this->error_types ) ) {
 			return;
 		}
 

--- a/rollback-auto-update.php
+++ b/rollback-auto-update.php
@@ -134,7 +134,7 @@ class Rollback_Auto_Update {
 	 *
 	 * @param array $handler_args Array of data.
 	 *
-	 * @return array
+	 * @return array|void
 	 */
 	public function shutdown_handler( $handler_args ) {
 		$e = error_get_last();

--- a/rollback-auto-update.php
+++ b/rollback-auto-update.php
@@ -102,7 +102,7 @@ class Rollback_Auto_Update {
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
 		set_error_handler( [ $this, 'error_handler' ], ( E_ALL ^ $this->error_types ) );
 		set_exception_handler( [ $this, 'exception_handler' ] );
-		register_shutdown_function( [ $this, 'shutdown_handler' ], $this->handler_args );
+		register_shutdown_function( [ $this, 'shutdown_handler' ] );
 	}
 
 	/**
@@ -124,10 +124,8 @@ class Rollback_Auto_Update {
 	/**
 	 * Displays fatal error output for sites running PHP < 7.
 	 * Liberally borrowed from John Blackbourn's Query Monitor.
-	 *
-	 * @param array $handler_args Array of data.
 	 */
-	public function shutdown_handler( $handler_args ) {
+	public function shutdown_handler() {
 		$e = error_get_last();
 
 		if ( empty( $e ) || ! ( $e['type'] & $this->error_types ) ) {
@@ -138,9 +136,9 @@ class Rollback_Auto_Update {
 			return;
 		}
 
-		$handler_args['handler_error'] = $e['type'] & E_RECOVERABLE_ERROR ? 'Recoverable fatal error' : 'Fatal error';
+		$this->handler_args['handler_error'] = $e['type'] & E_RECOVERABLE_ERROR ? 'Recoverable fatal error' : 'Fatal error';
 
-		$this->handler( $handler_args );
+		$this->handler();
 	}
 
 	/**

--- a/rollback-auto-update.php
+++ b/rollback-auto-update.php
@@ -143,19 +143,11 @@ class Rollback_Auto_Update {
 
 	/**
 	 * Handles errors by running Rollback.
-	 *
-	 * @param array $args {
-	 *    An array of error data.
-	 *
-	 *    @type string   $error      The error message.
-	 *    @type WP_Error $result     Generic WP_Error reporting unexpected output.
-	 *    @type array    $hook_extra Extra arguments that were passed to hooked filters.
-	 * }
 	 */
-	private function handler( $args ) {
-		$this->cron_rollback( $args );
-		$this->log_error_msg( $args );
-		$this->send_fatal_error_email( $args );
+	private function handler() {
+		$this->cron_rollback( $this->handler_args );
+		$this->log_error_msg( $this->handler_args );
+		$this->send_fatal_error_email( $this->handler_args );
 	}
 
 	/**

--- a/rollback-auto-update.php
+++ b/rollback-auto-update.php
@@ -132,7 +132,7 @@ class Rollback_Auto_Update {
 			return;
 		}
 
-		if ( 'Shutdown Caught' !== $this->handler_args['handler_error'] ) {
+		if ( ! empty( $this->handler_args['handler_error'] ) || 'Shutdown Caught' !== $this->handler_args['handler_error'] ) {
 			return;
 		}
 


### PR DESCRIPTION
This PR:
- [x] Adds a new `$error_types` property instead of using a third-party constant.
- [x] Uses the `$handler_args` property in place of a direct `$args` parameter for maintainability and less repetition in docblocks.
- [x] Removes unused arguments from methods.
- [x] Adds a guard in `shutdown_handler()`.
- [x] Docs: Corrects `@return` annotations.
- [x] Docs: Removes unnecessary `void`-only `@return` annotations.
- [x] Docs: Uses third-person singular verbs for method descriptions, in line with WordPress Core.
- [x] Docs: Capitalizes an inline comment for consistency.