### PR TITLE
Implement an alternative approach to checking errors in a new plugin version.

### DIFF
--- a/rollback-auto-update.php
+++ b/rollback-auto-update.php
@@ -39,21 +39,6 @@ if ( ! defined( 'WPINC' ) ) {
  * Class Auto_Update_Failure_Check
  */
 class Rollback_Auto_Update {
-
-	/**
-	 * Stores handler parameters.
-	 *
-	 * @var array
-	 */
-	private $handler_args = [];
-
-	/**
-	 * Stores error codes.
-	 *
-	 * @var int
-	 */
-	public $error_types = E_ERROR | E_PARSE | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR;
-
 	/**
 	 * Constructor, let's get going.
 	 */

--- a/rollback-auto-update.php
+++ b/rollback-auto-update.php
@@ -182,7 +182,6 @@ class Rollback_Auto_Update {
 			__( '%1$s was successfully updated on your site at %2$s.' ) . "\n\n" .
 			/* translators: 1: The name of the plugin or theme. */
 			__( 'However, due to a fatal error, %1$s, was reverted to the previously installed version. If a new version is released without fatal errors, it will be installed automatically.' ) . "\n\n" .
-			__( 'Please be aware that some additional auto-updates may not have been performed due the nature of the error seen.' ),
 			$name,
 			home_url()
 		);

--- a/rollback-auto-update.php
+++ b/rollback-auto-update.php
@@ -159,7 +159,7 @@ class Rollback_Auto_Update {
 	}
 
 	/**
-	 * Sends an email to the site administrator when a plugin
+	 * Sends an email to the site administrator when a plugin's
 	 * new version contains a fatal error.
 	 *
 	 * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.

--- a/rollback-auto-update.php
+++ b/rollback-auto-update.php
@@ -180,8 +180,8 @@ class Rollback_Auto_Update {
 			__( 'Howdy!' ) . "\n\n" .
 			/* translators: 1: The name of the plugin or theme. 2: Home URL. */
 			__( '%1$s was successfully updated on your site at %2$s.' ) . "\n\n" .
-			/* translators: 1: The name of the plugin or theme. */
-			__( 'However, due to a fatal error, %1$s, was reverted to the previously installed version. If a new version is released without fatal errors, it will be installed automatically.' ) . "\n\n" .
+			__( 'However, due to a fatal error, it was reverted to the previously installed version to keep your site running.' ) . ' ' .
+			__( 'If a new version is released without fatal errors, it will be installed automatically.' ) . "\n\n",
 			$name,
 			home_url()
 		);

--- a/rollback-auto-update.php
+++ b/rollback-auto-update.php
@@ -171,6 +171,11 @@ class Rollback_Auto_Update {
 
 		$plugin_path = $wp_filesystem->wp_plugins_dir() . $plugin;
 		$name        = \get_plugin_data( $plugin_path )['Name'];
+		$subject     = sprintf(
+			/* translators: %s: The site name. */
+			__( '[%s] A plugin was rolled back to the previously installed version' ),
+			get_bloginfo( 'name' )
+		);
 		$body        = sprintf(
 			__( 'Howdy!' ) . "\n\n" .
 			/* translators: 1: The name of the plugin or theme. 2: Home URL. */
@@ -184,7 +189,7 @@ class Rollback_Auto_Update {
 
 		$body .= "\n\n" . __( 'The WordPress Rollback Team' ) . "\n";
 
-		wp_mail( get_bloginfo( 'admin_email' ), __( 'Plugin auto-update failed due to a fatal error' ), $body );
+		wp_mail( get_bloginfo( 'admin_email' ), $subject, $body );
 	}
 }
 

--- a/rollback-auto-update.php
+++ b/rollback-auto-update.php
@@ -52,7 +52,7 @@ class Rollback_Auto_Update {
 	 * @param array|WP_Error $result     Result from WP_Upgrader::install_package().
 	 * @param array          $hook_extra Extra arguments passed to hooked filters.
 	 *
-	 * @return array|WP_Error
+	 * @return array|WP_Error The result from WP_Upgrader::install_package(), or a WP_Error object.
 	 */
 	public function auto_update_check( $result, $hook_extra ) {
 		if ( is_wp_error( $result ) || ! wp_doing_cron() || ! isset( $hook_extra['plugin'] ) ) {


### PR DESCRIPTION
This PR implements an alternative approach which:
- [x] Scrapes the plugin for an error the same way that `plugins.php` does (like, literally uses `plugins.php`).
- [x] Rolls a failing plugin back to its previous version.
- [x] Sends an error email for a failing plugin.
- [x] Continues with other plugin auto-updates.
- [x] No longer requires `handler_args`, `error_codes`, or any error/exception/shutdown handlers/logging.
- [x] Modifies the email subject for more consistency with Core.
- [x] Modifies the email body to remove the "Please be aware that some additional auto-updates may not have been performed due the nature of the error seen." as this is no longer needed.
- [x] Adds "to keep your site running" to remind site owners that we're good people. (Aren't we? 🤔)
- [x] Ninja-edits the email text to remove the second instance of the plugin name. Not a hill I'll die on, so feel free to revert if it reads better to you the previous way.

There is one current known caveat: The "success" email also includes the failing plugin, but a second email arrives to note the issue. If we can remove the failing plugin from the success email, I think that's the cleanest result.

I've tested this by unbumping the following plugins before running an auto-update: `akismet, classic-editor, rollback-fatal-plugin, transients-manager, wp-crontrol`. All plugins updated successfully, and the fatalling plugin, `rollback-fatal-plugin`, was reverted to the previously installed version.

I have not yet tested with two fatalling plugins. This would be beneficial to test how robust this implementation is.